### PR TITLE
feat: Add whoami tag to paste upload in pb.sh template

### DIFF
--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -453,4 +453,5 @@ def manpage_docbook():
 
 @paste.route('/sh')
 def shell_func():
-    return BaseResponse(render_template("pb.sh"), mimetype="text/plain")
+    alias_whoami = current_app.config.get('ALIAS_WHOAMI')
+    return BaseResponse(render_template("pb.sh", alias_whoami=alias_whoami), mimetype="text/plain")

--- a/pb/templates/pb.sh
+++ b/pb/templates/pb.sh
@@ -23,7 +23,8 @@ pb() {
     local post_path="/"
 
     # options
-    local clip=0 expires quiet=0 private=0
+    local clip=0 expires quiet=0 private=0 no_whoami=0
+    local tags=()
     local clip_cmd
     if _is_osx; then
         clip_cmd='pbcopy'
@@ -50,6 +51,8 @@ pb() {
             -p|--private) private=1;;
             -q|--quiet) quiet=1;;
             -c|--clip) clip=1;;
+            --no-whoami) no_whoami=1;;
+            -t|--tag) tags+=("$opt"); eval "$doshift";;
             -u|--url) post_path='/u';;
             -e|--expires) expires="$opt"; eval "$doshift";;
             -l|--label) post_path="$post_path~$opt"; eval "$doshift";;
@@ -110,6 +113,16 @@ pb() {
     if [ "$private" -eq 1 ]; then
         curlopts="${curlopts} -F p=1"
     fi
+
+    {% if alias_whoami %}
+    if [ "$no_whoami" -eq 0 ]; then
+        tags+=("{{ alias_whoami }}")
+    fi
+    {% endif %}
+
+    for tag in "${tags[@]}"; do
+        curlopts="${curlopts} -F \"t=${tag}\""
+    done
 
     curlcmd='curl -sS '"${curlopts}"' -F "c=@${input}" -w "%{redirect_url}'"$delim"'" "'"$pb_base$post_path"'?r=1" -o /dev/stderr '"$redir"
 


### PR DESCRIPTION
This tag can be opt-out by passing `--no-whoami`. If alias_whoami is not provided the app config, this CLI arg does nothing. User can specify extra tags using `-t=value`.