### PR TITLE
fix: any_url produces invalid URLs for pastes with shorter hashes

### DIFF
--- a/pb/responses.py
+++ b/pb/responses.py
@@ -25,7 +25,7 @@ def any_url(paste, filename=None):
         return idu('sha1', 'digest')
     if paste.get('label'):
         return idu('label', 'label')
-    return idu('sid', 'digest')
+    return idu('sid', 'short')
 
 def redirect(location, rv, code=302, **kwargs):
     response = current_app.response_class(rv, code, **kwargs)


### PR DESCRIPTION
1. Creating a paste that already exists from a long time ago will return an invalid URL to the user.

The paste "test" can be used to test this case.

2. The search page displays invalid URLs for older pastes.

Currently everything shows URL length 8 on the search page but some of them should be length 4 because the short hashes are length 6.