### PR TITLE
chore: Upgrade pymongo to 3.12.3

### DIFF
--- a/requirements.txt.lock
+++ b/requirements.txt.lock
@@ -6,7 +6,7 @@ Jinja2==2.9.5
 Markdown==2.6.8
 MarkupSafe==0.23
 Pygments==2.2.0
-pymongo==3.4.0
+pymongo==3.12.3
 python-dateutil==2.6.0
 python-magic==0.4.12
 pytz==2016.10


### PR DESCRIPTION
Required to interface with mongo 8.2.3