### PR TITLE
Add label search filter and autocompletions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,9 @@ DEFAULT_SEARCH_LIMIT: 100
 # Maximum limit allowed in one search request.
 MAX_SEARCH_LIMIT: 500
 
+# Maximum character length for paste labels.
+MAX_LABEL_LENGTH: 128
+
 #VARNISH_BASE: 'http://[::1]:8080/'
 
 #CDN_PREFIX: '//d34zelngniy2d8.cloudfront.net'

--- a/pb/cache.py
+++ b/pb/cache.py
@@ -63,7 +63,9 @@ def invalidate(**kwargs):
     return paste
 
 def add_cache_header(response):
-    if request.method == 'GET' and not response.cache_control.public:
+    if request.path.startswith('/search'):
+        response.cache_control.no_cache = True
+    elif request.method == 'GET' and not response.cache_control.public:
         prefix = request.blueprint if request.blueprint else current_app.name
         # ugh
         etag = "{}-{}".format(prefix, sha1(response.data).hexdigest())

--- a/pb/paste/model.py
+++ b/pb/paste/model.py
@@ -96,6 +96,9 @@ def get_meta(**kwargs):
         transform(kwargs)
     )
 
+def get_distinct(field):
+    return get_db().pastes.distinct(field)
+
 def get_search_results(**kwargs):
     return get_db().pastes.find(
         transform(kwargs),

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -102,6 +102,20 @@ def _search_pastes(limit):
 
     return pastes, nextCursor
 
+@paste.route('/search/distinct/<field>')
+def distinct(field):
+    # URL field name -> MongoDB field name
+    valid_distinct_fields = {
+        'tags': 'tags',
+        'mimetypes': 'mimetype',
+    }
+
+    db_field = valid_distinct_fields.get(field)
+    if not db_field:
+        return StatusResponse("invalid field", 400)
+    values = [v for v in model.get_distinct(db_field) if v]
+    return jsonify(sorted(values))
+
 @paste.route('/search')
 def search():
     defaultSearchLimit = current_app.config.get("DEFAULT_SEARCH_LIMIT", 100)

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -108,6 +108,7 @@ def distinct(field):
     valid_distinct_fields = {
         'tags': 'tags',
         'mimetypes': 'mimetype',
+        'labels': 'label',
     }
 
     db_field = valid_distinct_fields.get(field)

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -16,7 +16,7 @@ from urllib.parse import urlencode
 
 from datetime import timedelta, datetime
 
-from flask import Blueprint, request, render_template, current_app, jsonify, make_response
+from flask import Blueprint, request, render_template, current_app, jsonify
 from pygments.formatters import HtmlFormatter, get_all_formatters
 from pygments.lexers import get_all_lexers
 from pygments.styles import get_all_styles
@@ -139,11 +139,7 @@ def search():
         })
 
     if mimetype == "text/html":
-        response = make_response(render_template("search.html", results=pastes, nextUrl=nextUrl))
-        response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
-        response.headers["Pragma"] = "no-cache"
-        response.headers["Expires"] = "0"
-        return response
+        return render_template("search.html", results=pastes, nextUrl=nextUrl)
 
     return "", 406
 

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -201,8 +201,9 @@ def post(label=None, namespace=None):
 
     if label:
         label, _ = label
-        if len(label) == 1:
-            return StatusResponse("invalid label", 400)
+        max_label_length = current_app.config.get("MAX_LABEL_LENGTH", 128)
+        if len(label) < 2 or len(label) > max_label_length:
+            return StatusResponse(f"label must be between 2 and {max_label_length} characters", 400)
         args['label'] = label
     if namespace:
         host = get_host_name(request)

--- a/pb/static/js/index.js
+++ b/pb/static/js/index.js
@@ -77,6 +77,10 @@ var API = (function(baseurl) {
     }
 
     function post(data, uri) {
+        var label = $('#label').val();
+        if (label) {
+            uri = '~' + encodeURIComponent(label);
+        }
         return request({
             method: 'POST',
             uri: uri,

--- a/pb/templates/index.html
+++ b/pb/templates/index.html
@@ -247,7 +247,10 @@
             </div>
             <div class="form-group">
               <label for="label" class="sr-only">Label</label>
-              <input type="text" id="label" class="form-control" placeholder="Label" disabled="disabled">
+              <div class="input-group">
+                <span class="input-group-addon">~</span>
+                <input type="text" id="label" class="form-control" placeholder="Label" disabled="disabled">
+              </div>
             </div>
           </div>
 

--- a/pb/templates/search.html
+++ b/pb/templates/search.html
@@ -49,6 +49,11 @@
         <input type="text" class="form-control" id="mimetype" name="mimetype" autocomplete="off"
           value="{{ request.args.get('mimetype', '') }}">
       </div>
+      <div class="form-group">
+        <label for="label">Label:</label>
+        <input type="text" class="form-control" id="label" name="label" autocomplete="off"
+          value="{{ request.args.get('label', '') }}">
+      </div>
       <button type="submit" class="btn btn-primary">Search</button>
     </form>
     {% if nextUrl %}
@@ -115,7 +120,7 @@
 
   var distinctCache = {};
   // Maps input element IDs to /search/distinct/<field> values
-  var fieldMap = { tag: 'tags', mimetype: 'mimetypes' };
+  var fieldMap = { tag: 'tags', mimetype: 'mimetypes', label: 'labels' };
 
   function fetchDistinct(field, cb) {
     if (distinctCache[field]) {
@@ -159,7 +164,7 @@
     listEl.style.display = 'block';
   }
 
-  ['tag', 'mimetype'].forEach(function(id) {
+  ['tag', 'mimetype', 'label'].forEach(function(id) {
     var input = document.getElementById(id);
     var key = fieldMap[id];
     var listEl = document.createElement('ul');
@@ -222,12 +227,16 @@
     var params = new URLSearchParams();
     var tag = document.getElementById('tag').value.trim();
     var mimetype = document.getElementById('mimetype').value.trim();
+    var label = document.getElementById('label').value.trim();
 
     if (tag) {
       params.set('tag', tag);
     }
     if (mimetype) {
       params.set('mimetype', mimetype);
+    }
+    if (label) {
+      params.set('label', label);
     }
     // This will reload the page.
     window.location.search = params.toString();

--- a/pb/templates/search.html
+++ b/pb/templates/search.html
@@ -33,6 +33,30 @@
   .autocomplete-list li.active {
     background: #eee;
   }
+  @media (min-width: 1400px) {
+    .container { width: 1370px; }
+  }
+  .search-results {
+    table-layout: fixed;
+    width: 100%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+  .col-time {
+    width: 15%;
+  }
+  .col-link {
+    width: 25%;
+  }
+  .col-label {
+    width: 15%;
+  }
+  .col-mimetype {
+    width: 15%;
+  }
+  .col-size {
+    width: 10%;
+  }
 </style>
 {% endblock %} {% block body_nowrap %}
 <div class="container">
@@ -60,28 +84,28 @@
     <button id="next-page" class="btn" onclick="goToNextPage(event)">Next Page</button>
     {% endif %}
   </div>
-  <table class="table table-striped table-bordered table-hover">
+  <table class="table table-striped table-bordered table-hover search-results">
     <thead class="table-dark">
       <tr>
-        <th>Time (UTC)</th>
-        <th>Link</th>
-        <th>Label</th>
+        <th class="col-time">Time (UTC)</th>
+        <th class="col-link">Link</th>
+        <th class="col-label">Label</th>
+        <th class="col-mimetype">Mimetype</th>
         <th>Tags</th>
-        <th>Mimetype</th>
-        <th class="text-right">Size</th>
+        <th class="col-size text-right">Size</th>
       </tr>
     </thead>
     <tbody>
       {% if results %} {% for item in results %}
       <tr>
-        <td>{{ item.date.strftime('%b %d, %Y %I:%M %p') }}</td>
-        <td>
+        <td class="col-time">{{ item.date.strftime('%b %d, %Y %I:%M %p') }}</td>
+        <td class="col-link">
           <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url }}</a>
         </td>
-        <td>{{ item.get('label', '') }}</td>
+        <td class="col-label">{{ item.get('label', '') }}</td>
+        <td class="col-mimetype">{{ item.get('mimetype', '') }}</td>
         <td>{{ item.get('tags', []) | join(', ') }}</td>
-        <td>{{ item.get('mimetype', '') }}</td>
-        <td class="text-right">
+        <td class="col-size text-right">
           {% set size = item.get('size', 0) %}
           {% set KB = 1024 %}
           {% set MB = KB**2 %}

--- a/pb/templates/search.html
+++ b/pb/templates/search.html
@@ -10,6 +10,29 @@
     margin-top: 16px;
     margin-bottom: 24px;
   }
+  .autocomplete-list {
+    position: absolute;
+    z-index: 1000;
+    max-height: 200px;
+    overflow-y: auto;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 0 0 4px 4px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+  .autocomplete-list li {
+    padding: 6px 10px;
+    cursor: pointer;
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
+  .autocomplete-list li:hover,
+  .autocomplete-list li.active {
+    background: #eee;
+  }
 </style>
 {% endblock %} {% block body_nowrap %}
 <div class="container">
@@ -18,11 +41,12 @@
     <form id="searchForm" class="form-inline" onsubmit="updateQueryString(event)">
       <div class="form-group">
         <label for="tag">Tag:</label>
-        <input type="text" class="form-control" id="tag" name="tag" value="{{ request.args.get('tag', '') }}">
+        <input type="text" class="form-control" id="tag" name="tag" autocomplete="off"
+          value="{{ request.args.get('tag', '') }}">
       </div>
       <div class="form-group">
         <label for="mimetype">Mimetype:</label>
-        <input type="text" class="form-control" id="mimetype" name="mimetype"
+        <input type="text" class="form-control" id="mimetype" name="mimetype" autocomplete="off"
           value="{{ request.args.get('mimetype', '') }}">
       </div>
       <button type="submit" class="btn btn-primary">Search</button>
@@ -76,6 +100,123 @@
   </table>
 </div>
 <script>
+  // Subsequence match: "txpy" matches "text/x-python"
+  function fuzzyFilter(query, candidate) {
+    var q = query.toLowerCase();
+    var c = candidate.toLowerCase();
+    var qi = 0;
+    for (var ci = 0; ci < c.length && qi < q.length; ci++) {
+      if (c[ci] === q[qi]) {
+        qi++;
+      }
+    }
+    return qi === q.length;
+  }
+
+  var distinctCache = {};
+  // Maps input element IDs to /search/distinct/<field> values
+  var fieldMap = { tag: 'tags', mimetype: 'mimetypes' };
+
+  function fetchDistinct(field, cb) {
+    if (distinctCache[field]) {
+      return cb(distinctCache[field]);
+    }
+    $.getJSON('/search/distinct/' + field, function(data) {
+      distinctCache[field] = data;
+      cb(data);
+    });
+  }
+
+  function showSuggestions(input, listEl, items) {
+    var query = input.value.trim();
+    var matches = items.filter(function(item) {
+      return !query || fuzzyFilter(query, item);
+    });
+    if (query) {
+      matches.sort(function(a, b) { return a.length - b.length; });
+    }
+    listEl.innerHTML = '';
+    if (!matches.length) {
+      listEl.style.display = 'none';
+      return;
+    }
+
+    matches.forEach(function(item) {
+      var li = document.createElement('li');
+      li.textContent = item;
+      // mousedown fires before blur, so the click registers
+      li.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        input.value = item;
+        listEl.style.display = 'none';
+      });
+      listEl.appendChild(li);
+    });
+    var rect = input.getBoundingClientRect();
+    listEl.style.top = (rect.bottom + window.scrollY) + 'px';
+    listEl.style.left = (rect.left + window.scrollX) + 'px';
+    listEl.style.width = rect.width + 'px';
+    listEl.style.display = 'block';
+  }
+
+  ['tag', 'mimetype'].forEach(function(id) {
+    var input = document.getElementById(id);
+    var key = fieldMap[id];
+    var listEl = document.createElement('ul');
+    listEl.className = 'autocomplete-list';
+    listEl.style.display = 'none';
+    document.body.appendChild(listEl);
+
+    var activeIdx = -1;
+
+    function updateActive() {
+      var items = listEl.querySelectorAll('li');
+      items.forEach(function(li, i) {
+        li.classList.toggle('active', i === activeIdx);
+      });
+    }
+
+    input.addEventListener('focus', function() {
+      fetchDistinct(key, function(data) {
+        activeIdx = -1;
+        showSuggestions(input, listEl, data);
+      });
+    });
+    input.addEventListener('input', function() {
+      fetchDistinct(key, function(data) {
+        activeIdx = -1;
+        showSuggestions(input, listEl, data);
+      });
+    });
+    input.addEventListener('blur', function() {
+      listEl.style.display = 'none';
+      activeIdx = -1;
+    });
+    input.addEventListener('keydown', function(e) {
+      var items = listEl.querySelectorAll('li');
+      if (!items.length || listEl.style.display === 'none') {
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        activeIdx = Math.min(activeIdx + 1, items.length - 1);
+        updateActive();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        activeIdx = Math.max(activeIdx - 1, 0);
+        updateActive();
+      } else if (e.key === 'Enter' && activeIdx >= 0) {
+        e.preventDefault();
+        input.value = items[activeIdx].textContent;
+        listEl.style.display = 'none';
+        activeIdx = -1;
+      } else if (e.key === 'Escape') {
+        listEl.style.display = 'none';
+        activeIdx = -1;
+      }
+    });
+  });
+
   function updateQueryString(event) {
     event.preventDefault();
     var params = new URLSearchParams();

--- a/pb/templates/search.html
+++ b/pb/templates/search.html
@@ -65,6 +65,7 @@
       <tr>
         <th>Time (UTC)</th>
         <th>Link</th>
+        <th>Label</th>
         <th>Tags</th>
         <th>Mimetype</th>
         <th class="text-right">Size</th>
@@ -77,6 +78,7 @@
         <td>
           <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.url }}</a>
         </td>
+        <td>{{ item.get('label', '') }}</td>
         <td>{{ item.get('tags', []) | join(', ') }}</td>
         <td>{{ item.get('mimetype', '') }}</td>
         <td class="text-right">
@@ -98,7 +100,7 @@
       </tr>
       {% endfor %} {% else %}
       <tr>
-        <td colspan="5" class="text-center text-muted">No results found.</td>
+        <td colspan="6" class="text-center text-muted">No results found.</td>
       </tr>
       {% endif %}
     </tbody>


### PR DESCRIPTION
- Enable the label field on the paste creation form, wiring it up to the backend which already supported it.
- Add a /search/distinct/ endpoint returning sorted unique values for tags, mimetypes, and labels.
- Add autocomplete dropdowns to the search form filters with fuzzy matching and keyboard navigation.
- Add a label filter to the search form. Mainly to find available labels as users can already fetch by label in URL.
- Skip cache middleware for search endpoints so new distinct-values responses aren't cached.
- Add a label column to the search results table.
- Enforce configurable max label length (default 128 via MAX_LABEL_LENGTH in config).
- Set fixed percentage-based column widths with word-wrap and a wider container breakpoint for large screens.